### PR TITLE
Grouping variable length strings

### DIFF
--- a/difftest/expected/nvarchar_length_11
+++ b/difftest/expected/nvarchar_length_11
@@ -1,0 +1,1 @@
+{"results":[[{"output_type":"nvarchar(255)","output_length":11}]]}

--- a/difftest/expected/nvarchar_length_254
+++ b/difftest/expected/nvarchar_length_254
@@ -1,0 +1,1 @@
+{"results":[[{"output_type":"nvarchar(255)","output_length":254}]]}

--- a/difftest/expected/nvarchar_length_256
+++ b/difftest/expected/nvarchar_length_256
@@ -1,0 +1,1 @@
+{"results":[[{"output_type":"nvarchar(max)","output_length":256}]]}

--- a/difftest/expected/varchar_length_11
+++ b/difftest/expected/varchar_length_11
@@ -1,0 +1,1 @@
+{"results":[[{"output_type":"varchar(255)","output_length":11}]]}

--- a/difftest/expected/varchar_length_254
+++ b/difftest/expected/varchar_length_254
@@ -1,0 +1,1 @@
+{"results":[[{"output_type":"varchar(255)","output_length":254}]]}

--- a/difftest/expected/varchar_length_256
+++ b/difftest/expected/varchar_length_256
@@ -1,0 +1,1 @@
+{"results":[[{"output_type":"varchar(max)","output_length":256}]]}

--- a/difftest/templates/test/nvarchar_length_test.sql
+++ b/difftest/templates/test/nvarchar_length_test.sql
@@ -1,0 +1,43 @@
+--parameters:
+--@consultationIds nvarchar consultationIds
+DECLARE @output_length int, @output_type varchar(16)
+
+select  @output_length = nvarchar_test_data_length
+from (select top (1) len(@consultationIds) as nvarchar_test_data_length
+from 	sys.objects) T;
+
+select @output_type = substring(st.text, charindex('nvarchar(', st.text),13)
+FROM sys.dm_exec_cached_plans AS cp
+CROSS APPLY sys.dm_exec_sql_text(cp.plan_handle) st
+WHERE cp.cacheobjtype = N'Compiled Plan'
+AND cp.objtype IN (N'Prepared')
+AND text like  '%nvarchar_test_data_length%'
+
+SELECT @output_type as output_type, @output_length as output_length;
+
+--# delete any plans associated with this test
+declare @sql nvarchar(max), @plan_handle varbinary(64)
+declare  curs_plans cursor for
+select plan_handle
+FROM sys.dm_exec_cached_plans AS cp
+CROSS APPLY sys.dm_exec_sql_text(cp.plan_handle) st
+WHERE cp.cacheobjtype = N'Compiled Plan'
+AND cp.objtype IN (N'Prepared')
+AND text like  '%nvarchar_test_data_length%'
+
+OPEN curs_plans
+FETCH NEXT FROM curs_plans INTO @plan_handle
+WHILE @@FETCH_STATUS = 0
+BEGIN
+
+	set @sql = N'DBCC FREEPROCCACHE (' + UPPER(MASTER.dbo.Fn_varbintohexstr(@plan_handle)) + ')'
+	print @sql
+	exec sp_executesql @sql
+
+	FETCH NEXT FROM curs_plans INTO @plan_handle
+END
+CLOSE curs_plans
+DEALLOCATE curs_plans
+
+
+

--- a/difftest/templates/test/varchar_length_test.sql
+++ b/difftest/templates/test/varchar_length_test.sql
@@ -1,0 +1,43 @@
+--parameters:
+--@consultationIds varchar consultationIds
+DECLARE @output_length int, @output_type varchar(16)
+
+select  @output_length = varchar_test_data_length
+from (select top (1) len(@consultationIds) as varchar_test_data_length
+from 	sys.objects) T;
+
+select @output_type = substring(st.text, charindex('varchar(', st.text),12)
+FROM sys.dm_exec_cached_plans AS cp
+CROSS APPLY sys.dm_exec_sql_text(cp.plan_handle) st
+WHERE cp.cacheobjtype = N'Compiled Plan'
+AND cp.objtype IN (N'Prepared')
+AND text like  '%varchar_test_data_length%'
+
+SELECT @output_type as output_type, @output_length as output_length;
+
+--# delete any plans associated with this test
+declare @sql nvarchar(max), @plan_handle varbinary(64)
+declare  curs_plans cursor for
+select plan_handle
+FROM sys.dm_exec_cached_plans AS cp
+CROSS APPLY sys.dm_exec_sql_text(cp.plan_handle) st
+WHERE cp.cacheobjtype = N'Compiled Plan'
+AND cp.objtype IN (N'Prepared')
+AND text like  '%varchar_test_data_length%'
+
+OPEN curs_plans
+FETCH NEXT FROM curs_plans INTO @plan_handle
+WHILE @@FETCH_STATUS = 0
+BEGIN
+
+	set @sql = N'DBCC FREEPROCCACHE (' + UPPER(MASTER.dbo.Fn_varbintohexstr(@plan_handle)) + ')'
+	print @sql
+	exec sp_executesql @sql
+
+	FETCH NEXT FROM curs_plans INTO @plan_handle
+END
+CLOSE curs_plans
+DEALLOCATE curs_plans
+
+
+

--- a/difftest/tests/nvarchar_length_11
+++ b/difftest/tests/nvarchar_length_11
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+# vi: ft=sh
+curl -s "http://${EPI_TEST_SERVER}:8080/simple/mssql/test/nvarchar_length_test.sql?consultationIds=thisisatest"

--- a/difftest/tests/nvarchar_length_254
+++ b/difftest/tests/nvarchar_length_254
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+# vi: ft=sh
+curl -s "http://${EPI_TEST_SERVER}:8080/simple/mssql/test/nvarchar_length_test.sql?consultationIds=CrytXkwoFlszvSvgUIWyCnlT0PizVGaZAE3AzcvmC6dSHseC58TkUzJebAs7E7AFCmTCbfkl1XdKplbRZ8NN2x5tIrpXdMOXDoYlDQvwTIpC2vJKDEPttfRKogi4hSVkaXo7RgDy3kGkwEquMUuGmXMAJNENv34LwkvT7EKlwQ9Vl503AnXPJGktyLql98CroG1DNdSOGsQJI9QNAE6tuLZ08HPN8g3yIJwlfTbYmC4T92FEA39jVj8yu0km4g"

--- a/difftest/tests/nvarchar_length_256
+++ b/difftest/tests/nvarchar_length_256
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+# vi: ft=sh
+curl -s "http://${EPI_TEST_SERVER}:8080/simple/mssql/test/nvarchar_length_test.sql?consultationIds=CrytXkwoFlszvSvgUIWyCnlT0PizVGaZAE3AzcvmC6dSHseC58TkUzJebAs7E7AFCmTCbfkl1XdKplbRZ8NN2x5tIrpXdMOXDoYlDQvwTIpC2vJKDEPttfRKogi4hSVkaXo7RgDy3kGkwEquMUuGmXMAJNENv34LwkvT7EKlwQ9Vl503AnXPJGktyLql98CroG1DNdSOGsQJI9QNAE6tuLZ08HPN8g3yIJwlfTbYmC4T92FEA39jVj8yu0km4gpr"

--- a/difftest/tests/varchar_length_11
+++ b/difftest/tests/varchar_length_11
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+# vi: ft=sh
+curl -s "http://${EPI_TEST_SERVER}:8080/simple/mssql/test/varchar_length_test.sql?consultationIds=thisisatest"

--- a/difftest/tests/varchar_length_254
+++ b/difftest/tests/varchar_length_254
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+# vi: ft=sh
+curl -s "http://${EPI_TEST_SERVER}:8080/simple/mssql/test/varchar_length_test.sql?consultationIds=CrytXkwoFlszvSvgUIWyCnlT0PizVGaZAE3AzcvmC6dSHseC58TkUzJebAs7E7AFCmTCbfkl1XdKplbRZ8NN2x5tIrpXdMOXDoYlDQvwTIpC2vJKDEPttfRKogi4hSVkaXo7RgDy3kGkwEquMUuGmXMAJNENv34LwkvT7EKlwQ9Vl503AnXPJGktyLql98CroG1DNdSOGsQJI9QNAE6tuLZ08HPN8g3yIJwlfTbYmC4T92FEA39jVj8yu0km4g"

--- a/difftest/tests/varchar_length_256
+++ b/difftest/tests/varchar_length_256
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+# vi: ft=sh
+curl -s "http://${EPI_TEST_SERVER}:8080/simple/mssql/test/varchar_length_test.sql?consultationIds=CrytXkwoFlszvSvgUIWyCnlT0PizVGaZAE3AzcvmC6dSHseC58TkUzJebAs7E7AFCmTCbfkl1XdKplbRZ8NN2x5tIrpXdMOXDoYlDQvwTIpC2vJKDEPttfRKogi4hSVkaXo7RgDy3kGkwEquMUuGmXMAJNENv34LwkvT7EKlwQ9Vl503AnXPJGktyLql98CroG1DNdSOGsQJI9QNAE6tuLZ08HPN8g3yIJwlfTbYmC4T92FEA39jVj8yu0km4gpr"

--- a/src/drivers/mssql_base.coffee
+++ b/src/drivers/mssql_base.coffee
@@ -6,9 +6,9 @@ os              = require 'os'
 
 lowerCaseTediousTypeMap = {}
 
-# to make it so folks don't have to learn tedious' crazy casing of 
+# to make it so folks don't have to learn tedious' crazy casing of
 # data types, we'll keep a map of lower cased type names for comparison
-# to the inbound parameter type names ( in the case of a parameterized 
+# to the inbound parameter type names ( in the case of a parameterized
 # query request )
 for propertyName in Object.getOwnPropertyNames(tedious.TYPES)
   type = tedious.TYPES[propertyName]
@@ -161,8 +161,8 @@ class MSSQLDriver extends events.EventEmitter
         @emit 'error', error
     else
       # so, I really don't think it should but there are cases (in v1.13.0 at least) where the execSql method can
-      # raise an exception, so we'll attempt to handle that gracefully by catching errors, we'll also 
-      # take advantage of the fact that we have to do this to allow creation of errors in the 'transformValue' 
+      # raise an exception, so we'll attempt to handle that gracefully by catching errors, we'll also
+      # take advantage of the fact that we have to do this to allow creation of errors in the 'transformValue'
       # functions
       try
         parameters.forEach (param) =>
@@ -176,15 +176,15 @@ class MSSQLDriver extends events.EventEmitter
           # param declarations, so we're gonna start by fixing nvarchar and varchar lengths if they're
           # under a threshold, then we'll come back and add first class support for length
           if lowerCaseTypeName is 'varchar' or lowerCaseTypeName is 'nvarchar'
-            # if we have a value, we want to set the param length to 255 UNLESS it's greater 
+            # if we have a value, we want to set the param length to 255 UNLESS it's greater
             # so we don't truncate anything
-            if transformedValue
-              paramOptions.length = 255 unless transformedValue.length > 255
+            # there is a check here for no transformed value. if we have no value, thus our parameter value is null, so we'll just fix all our varchar
+            # length to 255 UNLESS they are values (not null) greater than 255 which is handled above
+            if transformedValue and transformedValue.length > 255
+              paramOptions.length = 8001
             else
-              # so here we have no value, thus our parameter value is null, so we'll just fix all our varchar
-              # lengthst to 255 UNLESS they are values (not null) greater than 255 which is handled above
               paramOptions.length = 255
-              
+
           request.addParameter(param.varName, tediousType, transformedValue, paramOptions)
         @conn.execSql request
       catch e


### PR DESCRIPTION
Instead of allowing strings greater than length 255 to be parameterized as their true length, round up to varchar/nvarchar(max) so we can take advantage of query plan cache re-use.