### PR TITLE
pin tough-cookie package to <3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "q": "0.9.2",
     "simplog": "0.2.2",
     "tedious": "2.0.0",
+    "tough-cookie": "<3.0.0",
     "sockjs": "igroff/sockjs-node#pass-headers",
     "underscore": "1.4.4",
     "xmla4js": "git+https://github.com/glg/xmla4js.git"


### PR DESCRIPTION
When deploying epiquery on my devship, I found an issue connecting to Salesforce (using the `sfdc` connection) caused by the dependency tree of the jsforce pacakge - `jsforce -> faye -> tough-cookie`. 

The tough-cookie package has been updated less than a month ago (at the time of writing) and the latest version requires a more up-to-date version of node due to a more modern syntax being used. I have tested this in my devship and all is now working correctly.

Thanks to @fearphage for pointing me towards the solution with this link https://github.com/faye/faye/issues/511