### PR TITLE
Added dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+#    ignore:
+#      - dependency-name: 'what to ignore'


### PR DESCRIPTION
Now that we have reliable tests, we can look at upgrading other dependencies. 

The result of this is that dependabot will create PRs weekly (probably immediately after the merge for the first run) telling us what dependencies are out of date. Because we have tests now, each upgraded dependency will be run against the full test suite. This will give us some type of of idea and confidence in the upgrade.

* Background: https://dependabot.com/ 
* Source: https://github.com/dependabot