### PR TITLE
request.params() is deprecated in Express 4

### DIFF
--- a/difftest/expected/params-parsed-from-body
+++ b/difftest/expected/params-parsed-from-body
@@ -1,0 +1,7 @@
+{
+  "events":[
+  {"queryId":"2","message":"beginquery"},
+  {"queryId":"2","data":"select 'parsed-from-body' as message\n","message":"data"},
+  {"queryId":"2","message":"endquery"}
+  ]
+}

--- a/difftest/expected/params-parsed-from-json
+++ b/difftest/expected/params-parsed-from-json
@@ -1,0 +1,7 @@
+{
+  "events":[
+  {"queryId":3,"message":"beginquery"},
+  {"queryId":3,"data":"select 'parsed-from-json' as message\n","message":"data"},
+  {"queryId":3,"message":"endquery"}
+  ]
+}

--- a/difftest/expected/params-parsed-from-query
+++ b/difftest/expected/params-parsed-from-query
@@ -1,0 +1,7 @@
+{
+  "events":[
+  {"queryId":"4","message":"beginquery"},
+  {"queryId":"4","data":"select 'parsed-from-query' as message\n","message":"data"},
+  {"queryId":"4","message":"endquery"}
+  ]
+}

--- a/difftest/expected/params-parsed-without-body
+++ b/difftest/expected/params-parsed-without-body
@@ -1,0 +1,7 @@
+{
+  "events":[
+  {"queryId":"6","message":"beginquery"},
+  {"queryId":"6","data":"select '' as message\n","message":"data"},
+  {"queryId":"6","message":"endquery"}
+  ]
+}

--- a/difftest/tests/params-parsed-from-body
+++ b/difftest/tests/params-parsed-from-body
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+curl --silent http://localhost:8080/render/test/echo.mustache \
+  --data 'message=parsed-from-body&queryId=2'

--- a/difftest/tests/params-parsed-from-body
+++ b/difftest/tests/params-parsed-from-body
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
-curl --silent http://localhost:8080/render/test/echo.mustache \
+# body overrides query param
+curl --silent http://localhost:8080/render/test/echo.mustache?queryId=1 \
   --data 'message=parsed-from-body&queryId=2'

--- a/difftest/tests/params-parsed-from-json
+++ b/difftest/tests/params-parsed-from-json
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-curl --silent http://localhost:8080/render/test/echo.mustache \
+# body overrides query param
+curl --silent http://localhost:8080/render/test/echo.mustache?queryId=1 \
   --header 'Content-Type: application/json' \
   --data '{"message":"parsed-from-json","queryId":3}'

--- a/difftest/tests/params-parsed-from-json
+++ b/difftest/tests/params-parsed-from-json
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+curl --silent http://localhost:8080/render/test/echo.mustache \
+  --header 'Content-Type: application/json' \
+  --data '{"message":"parsed-from-json","queryId":3}'

--- a/difftest/tests/params-parsed-from-query
+++ b/difftest/tests/params-parsed-from-query
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+curl --silent http://localhost:8080/render/test/echo.mustache?queryId=4 \
+  --data 'message=parsed-from-query'

--- a/difftest/tests/params-parsed-without-body
+++ b/difftest/tests/params-parsed-without-body
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl --silent http://localhost:8080/render/test/echo.mustache?queryId=6

--- a/epistream.coffee
+++ b/epistream.coffee
@@ -71,7 +71,10 @@ app.get '/stats', (req, res) ->
 
 httpRequestHandler = (req, res) ->
   c = new Context()
-  c.queryId = req.param 'queryId'
+  # there are no tests for req.params.queryId, but the implementation is based on
+  # the documentation for the deprecated request.params() method:
+  # http://expressjs.com/en/api.html#req.param
+  c.queryId = req.params.queryId || req.body?.queryId || req.query.queryId
   _.extend c, httpClient.getQueryRequestInfo(req, !!apiKey)
   # Check that the client supplied key matches server key
   if apiKey

--- a/epistream.coffee
+++ b/epistream.coffee
@@ -70,7 +70,6 @@ app.get '/stats', (req, res) ->
   res.send stats
 
 httpRequestHandler = (req, res) ->
-  clientId = req.param 'client_id'
   c = new Context()
   c.queryId = req.param 'queryId'
   _.extend c, httpClient.getQueryRequestInfo(req, !!apiKey)


### PR DESCRIPTION
Documentation: http://expressjs.com/en/api.html#req.param

This results in noise in the logs.

## Fix

The fix is to explicitly define the locations we look for the parameters (as defined by the docs).

## Note

* I removed an unused variable `clientId`. I couldn't find anywhere this was used nor referenced.

    ```shell
    ➜  epiquery2 git:(master) ag clientid
    epistream.coffee
    73:  clientId = req.param 'client_id'
    ➜  epiquery2 git:(master) ag client_id
    epistream.coffee
    73:  clientId = req.param 'client_id'
    ```

* `request.params.queryId` is untested although it was a part of the original implementation. To access this value, we'd need a request path that was defined as `/some/path/:queryId` which we do not have. I left it in based on the documentation although it is essentially useless. I'm open to removing it. I just copied the original implementation that we're replacing verbatim. I left a comment to this effect.