### PR TITLE
Patch JSForce to retry on network errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1273,6 +1273,11 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "commondir": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
@@ -1762,9 +1767,9 @@
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "faye": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.3.0.tgz",
-      "integrity": "sha512-l+IzAmEsT2OCVeGbLfZBpm8HeHQYVelkqKWNE0LA/k68jhVIT/qzHTXLygURrLpKweqiaTBCtzxxO5JTQ+dnFQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.4.0.tgz",
+      "integrity": "sha512-kRrIg4be8VNYhycS2PY//hpBJSzZPr/DBbcy9VWelhZMW3KhyLkQR0HL0k0MNpmVoNFF4EdfMFkNAWjTP65g6w==",
       "requires": {
         "asap": "*",
         "csprng": "*",
@@ -2200,9 +2205,8 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsforce": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsforce/-/jsforce-1.4.1.tgz",
-      "integrity": "sha1-17yv666HHeK+Z7VqzUw4OVKAhJ4=",
+      "version": "github:glg/jsforce#6a9ae4f8c0a14691757a6d83231abc4262e916af",
+      "from": "github:glg/jsforce#1.4.1-retry",
       "requires": {
         "co-prompt": "^1.0.0",
         "coffee-script": "^1.8.0",
@@ -2213,24 +2217,35 @@
         "q": "^1.1.2",
         "readable-stream": "^1.0.33",
         "request": "^2.51.0",
+        "requestretry": "3.0.1",
         "underscore": "^1.7.0",
         "xml2js": "^0.4.4"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
         "q": {
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
           "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
         },
+        "requestretry": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-3.0.1.tgz",
+          "integrity": "sha512-vJUdB4xucpx+Hc5N1hV44/fHmT4ovhrwGWfG9MtZR6AeO1G350IqPUXJL4gfZND6RtqoSqB+Zs9EeCsMizYf9A==",
+          "requires": {
+            "extend": "^3.0.2",
+            "lodash": "^4.17.10",
+            "when": "^3.7.7"
+          }
+        },
         "underscore": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-          "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
+          "integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "generic-pool": "2.2.0",
     "hogan.js": "3.0.2",
     "js-yaml": "3.6.0",
-    "jsforce": "1.4.1",
+    "jsforce": "glg/jsforce#1.4.1-retry",
     "line-by-line": "0.1.1",
     "lodash": "4.1.0",
     "lodash-contrib": "241.4.14",


### PR DESCRIPTION
Switching to the retry patched version of jsforce so we can avoid intermittent connection errors by retrying them